### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ It's uniqueness lies in the idea...
  3. Search for and click <kbd>ChroMATERIAL</kbd> and click <kbd>Install plugin</kbd>
 
 <!--
-####Manual
+#### Manual
 Install ChroMATERIAL. This does NOT provide automatic updates.
 
 **Retrieve from the Internet**


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
